### PR TITLE
fix deployment build error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
From heroku build log:
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       Yarn executable was not detected in the system.
       Download Yarn at https://yarnpkg.com/en/docs/install
       I, [2019-07-11T03:50:38.400208 #293]  INFO -- : Writing /tmp/build_a75b5073fcbce8df45dbfdfecb775aa4/public/assets/ckeditor/config-d8078db43298dc48e31702f2f7130d90657fbde671a5338be552fe53b4952a41.js
       I, [2019-07-11T03:50:38.400543 #293]  INFO -- : Writing /tmp/build_a75b5073fcbce8df45dbfdfecb775aa4/public/assets/ckeditor/config-d8078db43298dc48e31702f2f7130d90657fbde671a5338be552fe53b4952a41.js.gz
       I, [2019-07-11T03:50:38.402267 #293]  INFO -- : Writing /tmp/build_a75b5073fcbce8df45dbfdfecb775aa4/public/assets/ckeditor/config-d8078db43298dc48e31702f2f7130d90657fbde671a5338be552fe53b4952a41.js.gz
       rake aborted!
       Uglifier::Error: Unexpected token: name (Plugin). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).

Fix is : https://github.com/lautis/uglifier/issues/127